### PR TITLE
Improve error logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rpy"
 version = "0.2.4"
-edition = "2018"
+edition = "2024"
 description = "Run the appropriate python interpreter in the right way"
 authors = ["Matt Godbolt <matt.godbolt@aquatic.com>"]
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,12 @@
 
 use std::os::unix::process::CommandExt;
 use std::path::Path;
-use std::process::exit;
 use std::process::Command;
 use std::process::Stdio;
+use std::process::exit;
 use std::{env, fs};
 
-use eyre::{eyre, ContextCompat, Report, Result, WrapErr};
+use eyre::{ContextCompat, Report, Result, WrapErr, eyre};
 use serde::Deserialize;
 
 use crate::rpy::Rpy;
@@ -115,7 +115,7 @@ fn run() -> Result<()> {
 
 fn main() {
     if let Err(e) = run() {
-        eprintln!("[rpy] Error: {e}");
+        eprintln!("[rpy] Error: {e:?}");
         exit(1);
     }
 }

--- a/src/rpy.rs
+++ b/src/rpy.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::{env, fs};
 
-use eyre::{eyre, ContextCompat, Result, WrapErr};
+use eyre::{ContextCompat, Result, WrapErr, eyre};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum InvocationType {
@@ -132,7 +132,7 @@ impl Rpy {
             | InvocationType::Command(_) => env::current_dir().wrap_err("Unable to get cwd")?,
             InvocationType::File(filename) => {
                 let script_path = fs::canonicalize(Path::new(&filename))
-                    .wrap_err("unable to resolve project root")?;
+                    .wrap_err(format!("Failed to canonicalize \"{filename}\""))?;
                 if !script_path.is_file() {
                     return Err(eyre!(
                         "Unable to open input file: {}",

--- a/tests/rpy.rs
+++ b/tests/rpy.rs
@@ -9,9 +9,9 @@ fn should_fail_with_no_pyproject_toml() {
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert_eq!(stdout, "");
-    assert_eq!(
-        stderr,
-        "[rpy] Error: Unable to find pyproject.toml from /\n"
+    assert!(
+        stderr.starts_with("[rpy] Error: Unable to find pyproject.toml from /\n"),
+        "{stderr}"
     );
     assert_eq!(output.status.code().unwrap(), 1);
 }
@@ -25,9 +25,11 @@ fn should_fail_with_empty_pyproject_toml() {
     let stdout = std::str::from_utf8(&output.stdout).unwrap();
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert_eq!(stdout, "");
-    assert_eq!(
-        stderr,
-        "[rpy] Error: Unable to read toml document or find the rpy.tool configuration in it\n"
+    assert!(
+        stderr.starts_with(
+            "[rpy] Error: Unable to read toml document or find the rpy.tool configuration in it\n"
+        ),
+        "{stderr}"
     );
     assert_eq!(output.status.code().unwrap(), 1);
 }


### PR DESCRIPTION
Print the result of run() using debug formatting so that we display the full context.

Also, make the error message clearer.

Before:
```
[rpy] Error: unable to resolve project root
```

After:
```
[rpy] Error: Failed to canonicalize "nonexistent/path"

Caused by:
    No such file or directory (os error 2)

Location:
    src/rpy.rs:135:22
```
